### PR TITLE
Change default tag on test collections

### DIFF
--- a/orionutils/collections/collection_dep_a/galaxy.yml
+++ b/orionutils/collections/collection_dep_a/galaxy.yml
@@ -6,5 +6,5 @@ name: collection_dep_a
 namespace: orionuser1
 readme: README.md
 repository: http://github.example.com/orionuser1/collection_dep_a
-tags: [collectiontest]
+tags: [tools]
 version: 1.0.0

--- a/orionutils/collections/collection_dep_a1/galaxy.yml
+++ b/orionutils/collections/collection_dep_a1/galaxy.yml
@@ -8,4 +8,4 @@ license:
 readme: "README.md"
 repository: http://github.example.com/orionuser1/collection_dep_a1
 tags:
-  - collectiontest
+  - tools

--- a/orionutils/collections/searchfixture/galaxy.yml
+++ b/orionutils/collections/searchfixture/galaxy.yml
@@ -6,5 +6,5 @@ name: collection_dep_a
 namespace: orionuser1
 readme: README.md
 repository: http://github.example.com/orionuser1/searchfixture
-tags: [collectiontest]
+tags: [tools]
 version: 1.0.0

--- a/orionutils/collections/skeleton/galaxy.yml
+++ b/orionutils/collections/skeleton/galaxy.yml
@@ -6,5 +6,5 @@ name: collection_dep_a
 namespace: orionuser1
 readme: README.md
 repository: http://github.example.com/orionuser1/skeleton
-tags: [collectiontest]
+tags: [tools]
 version: 1.0.0


### PR DESCRIPTION
This default tag allows compatibility with galaxy-importer
REQUIRED_TAG_LIST when collection requires at least one required
tag via galaxy-importer config CHECK_REQUIRED_TAGS.