### PR TITLE
Some refactor and lots of tests.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,27 @@
+name: orionutils tests
+on: {pull_request: {branches: ['**']}, push: {branches: ['**']}}
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.after }}  # for PR avoids checking out merge commit
+          fetch-depth: 0  # include all history
+
+	  - name: run lint
+        run: make test/lint
+
+  units:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.after }}  # for PR avoids checking out merge commit
+          fetch-depth: 0  # include all history
+
+	  - name: run unit tests
+        run: make test/units
+

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,9 @@ jobs:
           ref: ${{ github.event.after }}  # for PR avoids checking out merge commit
           fetch-depth: 0  # include all history
 
+      - name: list files
+        run: pwd; ls -al
+
       - name: run lint
         run: make test/lint
 
@@ -21,6 +24,9 @@ jobs:
         with:
           ref: ${{ github.event.after }}  # for PR avoids checking out merge commit
           fetch-depth: 0  # include all history
+
+      - name: list files
+        run: pwd; ls -al
 
       - name: run unit tests
         run: make test/units

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,8 +10,10 @@ jobs:
           ref: ${{ github.event.after }}  # for PR avoids checking out merge commit
           fetch-depth: 0  # include all history
 
-      - name: list files
-        run: pwd; ls -al
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
 
       - name: run lint
         run: make test/lint
@@ -25,8 +27,10 @@ jobs:
           ref: ${{ github.event.after }}  # for PR avoids checking out merge commit
           fetch-depth: 0  # include all history
 
-      - name: list files
-        run: pwd; ls -al
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
 
       - name: run unit tests
         run: make test/units

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
           ref: ${{ github.event.after }}  # for PR avoids checking out merge commit
           fetch-depth: 0  # include all history
 
-	  - name: run lint
+      - name: run lint
         run: make test/lint
 
   units:
@@ -22,6 +22,6 @@ jobs:
           ref: ${{ github.event.after }}  # for PR avoids checking out merge commit
           fetch-depth: 0  # include all history
 
-	  - name: run unit tests
+      - name: run unit tests
         run: make test/units
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.coverage
+build/*
+*.egg-info
+*.swp
+__pycache__
+MANIFEST.json

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include orionutils/collections/*
+include orionutils/collections/*/*
+include orionutils/collections/*/*/*

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 .PHONY: test/lint
 test/lint:
 	rm -rf /tmp/ovenv
-	virtualenv /tmp/ovenv
-	/tmp/ovenv/bin/pip install .
-	/tmp/ovenv/bin/pip install pyyaml
+	python3 -m virtualenv /tmp/ovenv
+	#/tmp/ovenv/bin/pip install .
+	#/tmp/ovenv/bin/pip install pyyaml
 	/tmp/ovenv/bin/pip install -r test_requirements.txt
 	/tmp/ovenv/bin/flake8 .
 
@@ -11,7 +11,7 @@ test/lint:
 .PHONY: test/units
 test/units:
 	rm -rf /tmp/ovenv
-	virtualenv /tmp/ovenv
+	python3 -m virtualenv /tmp/ovenv
 	/tmp/ovenv/bin/pip install .
 	/tmp/ovenv/bin/pip install pyyaml
 	/tmp/ovenv/bin/pip install -r test_requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,7 @@
 .PHONY: test/lint
 test/lint:
 	rm -rf /tmp/ovenv
-	python3.8 -m virtualenv /tmp/ovenv
-	#/tmp/ovenv/bin/pip install .
-	#/tmp/ovenv/bin/pip install pyyaml
+	python3.8 -m venv /tmp/ovenv
 	/tmp/ovenv/bin/pip install -r test_requirements.txt
 	/tmp/ovenv/bin/flake8 .
 
@@ -11,7 +9,7 @@ test/lint:
 .PHONY: test/units
 test/units:
 	rm -rf /tmp/ovenv
-	python3.8 -m virtualenv /tmp/ovenv
+	python3.8 -m venv /tmp/ovenv
 	/tmp/ovenv/bin/pip install .
 	/tmp/ovenv/bin/pip install pyyaml
 	/tmp/ovenv/bin/pip install -r test_requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+.PHONY: test/lint
+test/lint:
+	rm -rf /tmp/ovenv
+	virtualenv /tmp/ovenv
+	/tmp/ovenv/bin/pip install .
+	/tmp/ovenv/bin/pip install pyyaml
+	/tmp/ovenv/bin/pip install -r test_requirements.txt
+	/tmp/ovenv/bin/flake8 .
+
+
+.PHONY: test/units
+test/units:
+	rm -rf /tmp/ovenv
+	virtualenv /tmp/ovenv
+	/tmp/ovenv/bin/pip install .
+	/tmp/ovenv/bin/pip install pyyaml
+	/tmp/ovenv/bin/pip install -r test_requirements.txt
+	/tmp/ovenv/bin/coverage run --source=orionutils -m pytest --capture=no --verbose test/units
+	/tmp/ovenv/bin/coverage report -m

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: test/lint
 test/lint:
 	rm -rf /tmp/ovenv
-	python3 -m virtualenv /tmp/ovenv
+	python3.8 -m virtualenv /tmp/ovenv
 	#/tmp/ovenv/bin/pip install .
 	#/tmp/ovenv/bin/pip install pyyaml
 	/tmp/ovenv/bin/pip install -r test_requirements.txt
@@ -11,7 +11,7 @@ test/lint:
 .PHONY: test/units
 test/units:
 	rm -rf /tmp/ovenv
-	python3 -m virtualenv /tmp/ovenv
+	python3.8 -m virtualenv /tmp/ovenv
 	/tmp/ovenv/bin/pip install .
 	/tmp/ovenv/bin/pip install pyyaml
 	/tmp/ovenv/bin/pip install -r test_requirements.txt

--- a/orionutils/generator.py
+++ b/orionutils/generator.py
@@ -71,11 +71,11 @@ class CollectionSetup:
 
         if cfg:
             with open(path, "w") as f:
-                print(f"DOCUMENTATION='''", file=f)
-                print(f"---", file=f)
+                print("DOCUMENTATION='''", file=f)
+                print("---", file=f)
                 for key in cfg:
                     print(f"{key}: {cfg[key]}", file=f)
-                print(f"'''", file=f)
+                print("'''", file=f)
 
     def __call__(self, name, key, checkout):
         """Create a new collection, populating it with configured contents."""
@@ -149,11 +149,11 @@ def randstr(length=8, seed=None):
 
 def build_collection(
     base: str,
-    config: dict=None,
-    filename: str=None,
-    key: str=None,
-    pre_build: Callable=None,
-    extra_files: dict=None,
+    config: dict = None,
+    filename: str = None,
+    key: str = None,
+    pre_build: Callable = None,
+    extra_files: dict = None,
 ) -> CollectionArtifact:
     """Build and return a CollectionArtifact
 
@@ -238,8 +238,10 @@ def build_collection(
                 yaml.dump(extra_files[filename], f)
 
     logger.info(f"Building collection {name} at {checkout}")
-    cmd_str = f"ansible-galaxy collection build -vvv"
-    p = subprocess.run(cmd_str, cwd=checkout, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    cmd_str = "ansible-galaxy collection build -vvv"
+    p = subprocess.run(
+        cmd_str, cwd=checkout, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+    )
     stdout = p.stdout.decode('utf8')
     m = re.search(r"([-_/\w\d\.]+\.tar\.gz)", stdout)
     assert m, stdout

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,6 @@ max-line-length = 100
 select = E,F,W,D
 ignore = E128,D202,D205,D400,D401,D413
 inline-quotes = "
+
+[options]
+include_package_data = True

--- a/test/units/test_generator.py
+++ b/test/units/test_generator.py
@@ -4,7 +4,6 @@ import tarfile
 import pytest
 import orionutils
 from orionutils.generator import build_collection
-from orionutils.generator import CollectionSetup
 
 
 def artifact_peek(filename):
@@ -37,7 +36,9 @@ def test_build_collection_skeleton_with_key():
 
 
 def test_build_collection_skeleton_with_namespace_name_version():
-    artifact = build_collection("skeleton", config={"namespace": "foo", "name": "bar", "version": "5.5.5"})
+    artifact = build_collection(
+        "skeleton", config={"namespace": "foo", "name": "bar", "version": "5.5.5"}
+    )
     assert artifact is not None
     assert os.path.exists(artifact.filename)
     install_path = os.path.dirname(orionutils.__file__)
@@ -79,5 +80,5 @@ def test_build_collection_skeleton_with_extra_files():
 
 def test_build_collection_skeleton_with_integer_version():
     with pytest.raises(ValueError) as excinfo:
-        artifact = build_collection("skeleton", config={"version": 3})
+        build_collection("skeleton", config={"version": 3})
     assert str(excinfo.value) == "version must be a string"

--- a/test/units/test_generator.py
+++ b/test/units/test_generator.py
@@ -1,0 +1,83 @@
+import json
+import os
+import tarfile
+import pytest
+import orionutils
+from orionutils.generator import build_collection
+from orionutils.generator import CollectionSetup
+
+
+def artifact_peek(filename):
+    fmap = {}
+    with tarfile.open(filename, mode='r:gz') as tar:
+        for member in tar:
+            try:
+                fmap[member.name] = tar.extractfile(member.name).read()
+            except AttributeError:
+                pass
+    return fmap
+
+
+def test_build_collection_skeleton():
+    artifact = build_collection("skeleton")
+    assert artifact is not None
+    assert os.path.exists(artifact.filename)
+    install_path = os.path.dirname(orionutils.__file__)
+    assert not artifact.filename.startswith(install_path)
+
+
+def test_build_collection_skeleton_with_key():
+    artifact = build_collection("skeleton", key="foobar")
+    assert artifact is not None
+    assert os.path.exists(artifact.filename)
+    install_path = os.path.dirname(orionutils.__file__)
+    assert not artifact.filename.startswith(install_path)
+    assert artifact.key == "foobar"
+    assert artifact.name.endswith("_foobar")
+
+
+def test_build_collection_skeleton_with_namespace_name_version():
+    artifact = build_collection("skeleton", config={"namespace": "foo", "name": "bar", "version": "5.5.5"})
+    assert artifact is not None
+    assert os.path.exists(artifact.filename)
+    install_path = os.path.dirname(orionutils.__file__)
+    assert not artifact.filename.startswith(install_path)
+
+    assert artifact.namespace == "foo"
+    assert artifact.name == "bar"
+    assert artifact.version == "5.5.5"
+
+    fmap = artifact_peek(artifact.filename)
+    meta = json.loads(fmap["MANIFEST.json"])
+    assert meta["collection_info"]["namespace"] == "foo"
+    assert meta["collection_info"]["name"] == "bar"
+    assert meta["collection_info"]["version"] == "5.5.5"
+
+
+def test_build_collection_skeleton_with_prebuild():
+
+    def this_prebuild(name, key, checkout):
+        assert name == "skeleton"
+        assert key == "foo"
+        assert os.path.exists(checkout)
+
+        role_dir = os.path.join(checkout, "roles", "foobar")
+        os.makedirs(role_dir)
+        with open(os.path.join(role_dir, "main.yml"), "w") as f:
+            f.write('# tasks')
+
+    artifact = build_collection("skeleton", pre_build=this_prebuild, key="foo")
+    fmap = artifact_peek(artifact.filename)
+    assert "roles/foobar/main.yml" in fmap
+
+
+def test_build_collection_skeleton_with_extra_files():
+    artifact = build_collection("skeleton", extra_files={"roles/foobar/main.yml": "# a role"})
+    fmap = artifact_peek(artifact.filename)
+    assert "roles/foobar/main.yml" in fmap
+
+
+def test_build_collection_skeleton_with_integer_version():
+    with pytest.raises(ValueError) as excinfo:
+        artifact = build_collection("skeleton", config={"version": 3})
+    assert str(excinfo.value) == "version must be a string"

--- a/test/units/test_utils.py
+++ b/test/units/test_utils.py
@@ -1,0 +1,7 @@
+from orionutils.utils import increment_version
+
+
+def test_increment_version():
+    v1 = "1.1.1"
+    v2 = increment_version(v1)
+    assert v2 == "1.1.2"

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,0 +1,4 @@
+coverage
+pytest
+pytest-cov
+pyyaml

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -2,3 +2,4 @@ coverage
 pytest
 pytest-cov
 pyyaml
+flake8


### PR DESCRIPTION
* Refactored the checkout path calculation to use a unique tempdir with a simpler folder structure that doesn't mimic the site-packages path.
* Added a makefile with lint and unit test targets
* Added a github action to run lint and units
* Lint uses flake8 based on the reference in setup.cfg
* Units cover most all functions except for the @attr.s decorated classes in generator.py as I'm not sure of their intended use.
* Created MANIFEST.in so that the pip install includes the collection skeleton directories and no longer requires an editable install to work.